### PR TITLE
fix rotate translate function (opTx)

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,5 +21,8 @@
   "bugs": {
     "url": "https://github.com/marklundin/glsl-sdf-ops/issues"
   },
-  "homepage": "https://github.com/marklundin/glsl-sdf-ops"
+  "homepage": "https://github.com/marklundin/glsl-sdf-ops",
+  "dependencies": {
+    "glsl-inverse": "^1.0.0"
+  }
 }

--- a/rotate-translate.glsl
+++ b/rotate-translate.glsl
@@ -1,6 +1,8 @@
+#pragma glslify: inverse = require(glsl-inverse)
+
 vec3 opTx( vec3 p, mat4 m )
 {
-    return q = invert( m ) * p;
+    return vec3(inverse( m ) * vec4(p, 1.0));
 }
 
 #pragma glslify: export(opTx)


### PR DESCRIPTION
I was getting errors when trying to use the `opTx` function. This sent me on a little journey of errors which this PR has now fixed. Here are the errors I got and a description of the change I made:

> Uncaught ERROR: 0:65: 'q' : undeclared identifier

- Removed `q`

> Uncaught ERROR: 0:65: 'invert' : no matching overloaded function found

- changed to use `glsl-inverse`

> Uncaught ERROR: 0:131: '*' : wrong operand types - no operation '*' exists that takes a left-hand operand of type 'mediump 4X4 matrix of float' and a right operand of type 'in mediump 3-component vector of float' (or there is no acceptable conversion)

- cast `vec3 p` to `vec4` in order to multiply with `mat4`

> Uncaught ERROR: 0:131: 'return' : function return is not matching type: vec3

- cast returned `vec4` to `vec3`